### PR TITLE
# Task. 11-1 Article model に下書き機能を追加【下書き機能の実装】

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -4,6 +4,7 @@
 #
 #  id         :bigint           not null, primary key
 #  body       :text
+#  status     :string           default(NULL)
 #  title      :string
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
@@ -20,4 +21,8 @@ class Article < ApplicationRecord
   has_many :article_likes, dependent: :destroy
 
   validates :title, :body, presence: true
+
+  # 0が「draft」、1が「published」で操作／参照できるようになる
+  # 公開済み(published) / 下書き(draft)
+  enum status: { published: 0, draft: 1 }
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,12 @@
 Rails.application.routes.draw do
   root to: "home#index"
 
+  # reload 対策
+  get "sign_up", to: "home#index"
+  get "sign_in", to: "home#index"
+  get "articles/new", to: "home#index"
+  get "articles/:id", to: "home#index"
+
   namespace :api do
     namespace :v1 do
       mount_devise_token_auth_for "User", at: "auth", controllers: {

--- a/db/migrate/20240201090427_add_status_to_articles.rb
+++ b/db/migrate/20240201090427_add_status_to_articles.rb
@@ -1,0 +1,5 @@
+class AddStatusToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :status, :string, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_12_05_100815) do
+ActiveRecord::Schema.define(version: 2024_02_01_090427) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 2023_12_05_100815) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "user_id"
+    t.string "status", default: "draft"
   end
 
   create_table "comments", force: :cascade do |t|

--- a/spec/factories/articles.rb
+++ b/spec/factories/articles.rb
@@ -1,8 +1,28 @@
+# == Schema Information
+#
+# Table name: articles
+#
+#  id         :bigint           not null, primary key
+#  body       :text
+#  status     :string           default(NULL)
+#  title      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  user_id    :bigint
+#
 FactoryBot.define do
   factory :article do
     title { Faker::Lorem.word } # ランダムな単語を生成
     body { Faker::Lorem.sentence } # ランダムな文章を生成
     user # articleに紐付くuserをランダムに生成
     # userはuserファクトリーがあるのでここではfaker記載不要　
+
+    trait :draft do
+      status { 1 }
+    end
+
+    trait :published do
+      status { 0 }
+    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 FactoryBot.define do
   factory :user do
     name { Faker::Lorem.characters(number: Random.new.rand(1..30)) }

--- a/spec/models/articles_spec.rb
+++ b/spec/models/articles_spec.rb
@@ -121,4 +121,31 @@ RSpec.describe "Api::V1::Articles", type: :request do
       end
     end
   end
+
+  describe "正常系" do
+    context "タイトルと本文が入力されているとき" do
+      let(:article) { build(:article) }
+
+      it "下書き状態の記事ができる" do
+        expect(article).to be_valid
+        # expect(article.status).to eq "draft: 1 "
+      end
+    end
+
+    context "status が下書き状態のとき" do
+      let(:article) { build(:article, :draft) }
+      it "記事を下書き状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "draft"
+      end
+    end
+
+    context "status が公開状態のとき" do
+      let(:article) { build(:article, :published) }
+      it "記事を公開状態で作成できる" do
+        expect(article).to be_valid
+        expect(article.status).to eq "published"
+      end
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,3 +1,33 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  allow_password_change  :boolean          default(FALSE)
+#  confirmation_sent_at   :datetime
+#  confirmation_token     :string
+#  confirmed_at           :datetime
+#  email                  :string
+#  encrypted_password     :string           default(""), not null
+#  image                  :string
+#  name                   :string
+#  provider               :string           default("email"), not null
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  tokens                 :json
+#  uid                    :string           default(""), not null
+#  unconfirmed_email      :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#
+# Indexes
+#
+#  index_users_on_confirmation_token    (confirmation_token) UNIQUE
+#  index_users_on_email                 (email) UNIQUE
+#  index_users_on_reset_password_token  (reset_password_token) UNIQUE
+#  index_users_on_uid_and_provider      (uid,provider) UNIQUE
+#
 require "rails_helper"
 
 # spec ファイルは３つの構文で成り立つ


### PR DESCRIPTION
- 記事の model に enum を使って下書きと公開の２つの状態を作る

- 最低限、以下の２つの条件での model のテストを追加
1. 下書き記事として保存できる
2. 公開記事として保存できる